### PR TITLE
상세 페이지에서 언급량 그래프, 최신 뉴스 크롤링 기능 추가

### DIFF
--- a/src/dashboard/components/emotionRate.jsx
+++ b/src/dashboard/components/emotionRate.jsx
@@ -29,7 +29,7 @@ export default function EmotionRate({ code }) {
         <p className="emotion-title">감성지수</p>
         <img className="question-mark" src={whitequestionmark} alt="questionmark" fill="white" />
       </div>
-      <div className="progress-bar" style={{ width: 102, height: 102 }}>
+      <div className="progress-bar">
         <CircularProgressbar
           value={emotionRate}
           text={`${emotionRate}`}

--- a/src/dashboard/components/indicator.jsx
+++ b/src/dashboard/components/indicator.jsx
@@ -37,6 +37,7 @@ export default function Indicator({ code, type }) {
         <img className="question-mark" src={questionmark} alt="questionmark" />
       </div>
       <ApexCharts
+        className="indicator-chart"
         type="bar"
         series={[{ name: "비율", data: data.rates }]}
         options={{
@@ -55,6 +56,9 @@ export default function Indicator({ code, type }) {
             axisBorder: { show: false },
             categories: data.categories,
             type: "string",
+          },
+          noData: {
+            text: "Loading...",
           },
           colors: ["#1FD286"],
           tooltip: {

--- a/src/dashboard/components/mentionAmount.jsx
+++ b/src/dashboard/components/mentionAmount.jsx
@@ -1,12 +1,95 @@
-import React from "react";
-import questionmark from "../../assets/image/questionmark.svg";
+import React, { useState, useEffect } from "react";
+import axios from "axios";
+import ApexCharts from "react-apexcharts";
+import "../styles/mentionAmount.css";
 
-export default function MentionAmount() {
+export default function MentionAmount({ name }) {
+  const [seriesData, setSeriesData] = useState([]);
+  const [categories, setCategories] = useState([]);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const response = await axios.get(`http://localhost:4000/api/trend?keywords=${name}`);
+        const data = response.data;
+        const periods = data.map((item) => item.period);
+        const ratios = data.map((item) => item.ratio);
+
+        const transformedPeriods = periods.map((item) => {
+          const date = item.split("-");
+          return date[1] + "/" + date[2];
+        });
+
+        setCategories(transformedPeriods);
+        setSeriesData(ratios);
+      } catch (error) {
+        console.error("Error fetching data", error);
+      }
+    }
+
+    fetchData();
+  }, [name]);
+
+  const options = {
+    chart: {
+      height: 365,
+      type: "line",
+      zoom: {
+        enabled: false,
+      },
+    },
+    dataLabels: {
+      enabled: false,
+    },
+    stroke: {
+      curve: "straight",
+    },
+    grid: {
+      row: {
+        colors: ["transparent"],
+        opacity: 0.5,
+      },
+    },
+    yaxis: {
+      labels: {
+        formatter: function (val) {
+          return val.toFixed(1);
+        },
+      },
+    },
+    xaxis: {
+      categories: categories,
+      tickAmount: Math.ceil(categories.length / 5),
+      labels: {
+        rotate: 0,
+        hideOverlappingLabels: true,
+      },
+    },
+    noData: {
+      text: "Loading...",
+      align: "center",
+      verticalAlign: "middle",
+    },
+  };
+
+  const series = [
+    {
+      name: "언급량",
+      data: seriesData,
+    },
+  ];
+
   return (
     <div className="mention-amount">
-      <div>
+      <div className="mention-header">
         <p className="mention-title">언급량</p>
-        <img className="question-mark" src={questionmark} alt="questionmark" />
+        <p className="mention-info">
+          최근 30일간 네이버에서의 <span style={{ fontWeight: "bold" }}>{name}</span> 검색량
+          추이입니다.
+        </p>
+      </div>
+      <div className="linechart">
+        <ApexCharts options={options} series={series} type="line" height="400" />
       </div>
     </div>
   );

--- a/src/dashboard/components/relatedNews.jsx
+++ b/src/dashboard/components/relatedNews.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import axios from "axios";
 import questionmark from "../../assets/image/questionmark.svg";
 import GetNews from "../services/newsCrawling";
-import { Table } from "react-bootstrap";
+import "../styles/relatedNews.css";
 
 export default function RelatedNews({ code }) {
   const [newsList, setNewsList] = useState([]);
@@ -15,7 +15,6 @@ export default function RelatedNews({ code }) {
         const response = await axios.get(`http://localhost:4000/api/stocksDetail/${code}`);
         const stockName = response.data.name;
         const news = await GetNews(stockName);
-        console.log(news);
         setNewsList(news);
       } catch (error) {
         console.error("Error fetching data", error);
@@ -27,36 +26,33 @@ export default function RelatedNews({ code }) {
 
   return (
     <div className="related-news">
-      <div>
-        <div>
-          <p className="news-title">관련 기사</p>
-          <p className="news-info">{today} 기준 집계된 데이터입니다.</p>
-        </div>
-        <img className="question-mark" src={questionmark} alt="questionmark" />
+      <div className="related-news-header">
+        <p className="related-news-title">관련 기사</p>
+        <p className="news-info">{today} 기준 집계된 데이터입니다.</p>
       </div>
       <div className="news-list">
-        <Table striped bordered hover>
+        <table>
           <thead>
             <tr>
-              <th>신문사</th>
-              <th>기사 제목</th>
-              <th>날짜</th>
+              <th className="news-company">신문사</th>
+              <th className="news-title">기사 제목</th>
+              <th className="news-date">날짜</th>
             </tr>
           </thead>
           <tbody>
             {newsList.map((news) => (
               <tr key={news.title}>
                 <td>{news.press}</td>
-                <td>
-                  <a href={news.link} target="_blank" rel="noreferrer">
+                <td className="news-title-content">
+                  <a href={news.url} target="_blank" rel="noreferrer">
                     {news.title}
                   </a>
                 </td>
-                <td>{news.date}</td>
+                <td className="news-date-content">{news.date}</td>
               </tr>
             ))}
           </tbody>
-        </Table>
+        </table>
       </div>
     </div>
   );

--- a/src/dashboard/components/stockInfo.jsx
+++ b/src/dashboard/components/stockInfo.jsx
@@ -75,7 +75,7 @@ export default function StockInfo({ code }) {
         </div>
         <img className="question-mark" src={questionmark} alt="questionmark" />
       </div>
-      <p className="stock-code">{code}</p>
+      <p className="stock-info-code">{code}</p>
       <p className="stock-price" style={{ color: color }}>
         {stockPrice}
       </p>

--- a/src/dashboard/dashboard.jsx
+++ b/src/dashboard/dashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import NavbarHeader from "../header/navbarHeader";
 import { Container, Row, Col } from "react-bootstrap";
 import "./styles/dashboard.css";
@@ -12,8 +12,17 @@ import { useParams } from "react-router-dom";
 
 export default function Dashboard() {
   const code = useParams().code;
+  const [stockName, setStockName] = useState("");
 
   const types = ["profit", "stability", "growth", "efficiency"];
+
+  useEffect(() => {
+    fetch(`http://localhost:4000/api/stocksDetail/${code}`)
+      .then((res) => res.json())
+      .then((data) => {
+        setStockName(data.name);
+      });
+  }, [code]);
 
   return (
     <div className="dashboard">
@@ -26,7 +35,7 @@ export default function Dashboard() {
               <StockInfo code={code} />
               <EmotionRate code={code} />
             </div>
-            <MentionAmount />
+            <MentionAmount name={stockName} />
             <RelatedNews code={code} />
           </Col>
           <Col sm={8} className="right-part">

--- a/src/dashboard/services/newsCrawling.jsx
+++ b/src/dashboard/services/newsCrawling.jsx
@@ -1,41 +1,9 @@
 import axios from "axios";
-import * as cheerio from "cheerio";
-
-const baseURL =
-  "https://search.daum.net/search?w=news&nil_search=btn&DA=NTB&enc=utf8&cluster=y&cluster_page=1&q=";
 
 export default async function GetNews(stockName) {
-  const resp = await axios.get("https://search.daum.net/search", {
-    params: {
-      w: "news",
-      cluster: "y",
-      q: stockName,
-      p: 1,
-    },
+  const response = await axios.get("http://localhost:4000/api/stocksDetail/proxy/news", {
+    params: { stockName },
   });
-  const data = await resp.data;
-  const $ = cheerio.load(data);
-  const newsList = $("ul.c-list-basic > li");
-  const newsParsed = newsList
-    .map((i, el) => {
-      return parseNews($(el));
-    })
-    .get();
-  console.log(newsParsed);
-  return newsParsed;
-}
-
-function parseNews(newsElem) {
-  const press = newsElem.find(".c-tit-doc .tit_item").prop("title");
-  const titleAnchor = newsElem.find(".c-item-content .item-title a");
-  const title = titleAnchor.text();
-  const url = titleAnchor.prop("href");
-  const date = newsElem.find(".c-item-content .item-contents .txt-info").text();
-
-  return {
-    press,
-    title,
-    url,
-    date,
-  };
+  console.log(response.data);
+  return response.data;
 }

--- a/src/dashboard/styles/dashboard.css
+++ b/src/dashboard/styles/dashboard.css
@@ -209,4 +209,5 @@ p {
 .indicators .indicator .indicator-title {
   font-size: 16px;
   font-weight: 700;
+  margin-bottom: 20px;
 }

--- a/src/dashboard/styles/dashboard.css
+++ b/src/dashboard/styles/dashboard.css
@@ -93,6 +93,13 @@ p {
   padding: 20px;
 }
 
+.emotion-rate {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100%;
+}
+
 .emotion-rate > div:first-child {
   display: flex;
   justify-content: space-between;
@@ -105,7 +112,10 @@ p {
 }
 
 .emotion-rate .progress-bar {
-  margin: 19px 0px 0px 52px;
+  width: 100%;
+  padding: 3px;
+  margin-top: 19px;
+  text-align: center;
 }
 
 /*언급량*/

--- a/src/dashboard/styles/dashboard.css
+++ b/src/dashboard/styles/dashboard.css
@@ -9,6 +9,7 @@ p {
 .dashboard {
   background-color: #f5f6fa;
   height: 100%;
+  min-width: 1401px;
 }
 
 .dashboard-container {
@@ -136,37 +137,6 @@ p {
 .mention-amount .mention-title {
   font-size: 20px;
   font-weight: 700;
-}
-
-/*관련 뉴스*/
-.related-news {
-  width: 100%;
-  height: 396px;
-  background-color: white;
-  border-radius: 6px;
-  margin-top: 21px;
-  padding: 23px 25px 0px 25px;
-}
-
-.related-news > div:first-child {
-  display: flex;
-  justify-content: space-between;
-}
-
-.related-news > div:first-child > div {
-  display: flex;
-  gap: 30px;
-  align-items: center;
-}
-
-.related-news .news-title {
-  font-size: 20px;
-  font-weight: 700;
-}
-
-.related-news .news-info {
-  color: #5a607f;
-  font-size: 14px;
 }
 
 /*right-part*/

--- a/src/dashboard/styles/dashboard.css
+++ b/src/dashboard/styles/dashboard.css
@@ -42,7 +42,7 @@ p {
 }
 
 .stock-info .stock-name {
-  font-size: 24px;
+  font-size: 22px;
   font-weight: 700;
   margin: 0px 6px 3px 0px;
 }
@@ -57,7 +57,7 @@ p {
   cursor: pointer;
 }
 
-.stock-info .stock-code {
+.stock-info .stock-info-code {
   color: #5a607f;
   font-size: 14px;
   margin-bottom: 51px;

--- a/src/dashboard/styles/mentionAmount.css
+++ b/src/dashboard/styles/mentionAmount.css
@@ -1,0 +1,20 @@
+@import url(https://fonts.googleapis.com/css);
+
+#chart {
+  max-width: 650px;
+  margin: 35px auto;
+}
+
+.apexcharts-menu-icon {
+  display: none;
+}
+
+.mention-header {
+  align-items: center;
+  margin-bottom: 3px;
+}
+
+.mention-info {
+  font-size: 13px;
+  color: #5a607f;
+}

--- a/src/dashboard/styles/relatedNews.css
+++ b/src/dashboard/styles/relatedNews.css
@@ -1,0 +1,81 @@
+/*관련 뉴스*/
+.related-news {
+  width: 100%;
+  height: 396px;
+  background-color: white;
+  border-radius: 6px;
+  margin-top: 21px;
+  padding: 23px 25px 0px 25px;
+}
+
+.related-news-header {
+  margin-bottom: 10px;
+}
+
+.related-news > div:first-child {
+  display: flex;
+  justify-content: space-between;
+}
+
+.related-news > div:first-child > div {
+  display: flex;
+  gap: 30px;
+  align-items: center;
+}
+
+.related-news .related-news-title {
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.related-news .news-info {
+  color: #5a607f;
+  font-size: 14px;
+}
+
+/*news-list*/
+.news-list > table tr {
+  border-bottom: 1px solid #d7dbec;
+}
+
+.news-list > table thead {
+  color: #5a607f;
+}
+
+.news-list {
+  font-size: 14px;
+  color: #131523;
+}
+
+.news-company {
+  width: 20%;
+}
+
+.news-title {
+  width: 60%;
+}
+
+.news-title-content {
+  padding: 3px 0px 2px 0;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+  line-height: 1.9em;
+}
+
+.news-title-content a {
+  text-decoration: none;
+  color: #131523;
+}
+
+.news-date {
+  width: 20%;
+  padding-left: 15px;
+}
+
+.news-date-content {
+  padding-left: 15px;
+}


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/dashboard -> main

### 진행률
90%

### 변경 사항
- 상세 페이지에 종목별 언급량 정보를 가져와서 그래프를 그려주는 기능을 추가했습니다.
- 종목 별 최신 뉴스 5개를 크롤링해오는 기능을 추가했습니다.(뉴스를 클릭하면 다음 뉴스 페이지로 이동하도록 해뒀습니다.)
- 최신 뉴스에서는 2줄이 넘어가면 ... 으로 끝나도록 처리했습니다.
- 리액트에서 크롤링을 하니까 CORS 에러가 터져서 백엔드에서 크롤링을 하고, 프론트엔드에서는 api를 호출하는 식으로 구현했습니다.
- 종목 장바구니에 담기 api 연동, 관련 키워드 워드 클라우드 남았습니다.

### 테스트 결과
- 정상 작동
<img width="1822" alt="image" src="https://github.com/user-attachments/assets/c742f9a7-b5b5-43f3-9456-5c8d2be4038c">
